### PR TITLE
Fix footer spacing in payment PDFs

### DIFF
--- a/js/admin_pagos.js
+++ b/js/admin_pagos.js
@@ -314,7 +314,7 @@ document.getElementById("btnDescargarPDF").addEventListener("click", function ()
 
     const finalY = doc.lastAutoTable.finalY || 85;
     doc.setFontSize(10);
-    doc.text("Thank you for your work." + NOMBRE_ESCUELA, 20, finalY + 20);
+    doc.text("Thank you for your work. " + NOMBRE_ESCUELA, 20, finalY + 20);
 
     doc.save(`payment_receipt_${profesor}_${fechaHoyNombre}.pdf`);
 });

--- a/js/profesor/profesor_pagos.js
+++ b/js/profesor/profesor_pagos.js
@@ -147,7 +147,7 @@ document.getElementById("btnDescargarComprobanteProfesor").addEventListener("cli
 
     const finalY = doc.lastAutoTable.finalY || 85;
     doc.setFontSize(10);
-    doc.text("Thank you for your work." + NOMBRE_ESCUELA, 20, finalY + 20);
+    doc.text("Thank you for your work. " + NOMBRE_ESCUELA, 20, finalY + 20);
 
     doc.save(`teacher_payment_receipt_${fechaHoyNombre}.pdf`);
 });


### PR DESCRIPTION
## Summary
- update admin and teacher payment PDFs to include a space before the school name

## Testing
- `grep -n "Thank you" -n js/admin_pagos.js js/profesor/profesor_pagos.js`

------
https://chatgpt.com/codex/tasks/task_e_6848479a77d4832291992c3edc611372