### PR TITLE
Fix email whitespace

### DIFF
--- a/php/test_email.php
+++ b/php/test_email.php
@@ -17,12 +17,12 @@ try {
     $mail->isSMTP();
     $mail->Host       = 'smtp.gmail.com';
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'rebelssicily@gmail.com '; // tu Gmail
+    $mail->Username   = 'rebelssicily@gmail.com'; // tu Gmail
     $mail->Password   = 'lftbvavtlagzdxft';    // contraseña de aplicación
     $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
     $mail->Port       = 587;
 
-    $mail->setFrom('rebelssicily@gmail.com ', 'Escuela de Surf');
+    $mail->setFrom('rebelssicily@gmail.com', 'Escuela de Surf');
     $mail->addAddress($correo_destino, $nombre_destino);
 
     // Email


### PR DESCRIPTION
## Summary
- trim trailing whitespace from email address in `test_email.php`

## Testing
- `php -l php/test_email.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684847aa22ec83228494df938b5ff476