### PR TITLE
Fix comment to show email sent when payment paid

### DIFF
--- a/php/actualizar_pago.php
+++ b/php/actualizar_pago.php
@@ -2,7 +2,7 @@
 // ===========================================================
 // File: actualizar_pago.php
 // Functionality: Updates the status of a payment in the database
-// and sends an email notification when the payment is marked as approved.
+// and sends an email notification when the payment is marked as paid.
 // ===========================================================
 
 require 'db.php'; // Import database connection


### PR DESCRIPTION
## Summary
- fix comment in `actualizar_pago.php` to mention that an email is sent when a payment is marked as paid

## Testing
- `php -l php/actualizar_pago.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684847b307e08322ab8bb1e764c0b5fc