### PR TITLE
Replace footer close button with top-right icon

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -195,6 +195,7 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
                 <div class="modal-dialog modal-dialog-centered modal-detalle-clase">
                     <!-- Modal Content -->
                     <div class="modal-content compacto">
+                        <button type="button" class="btn-close position-absolute top-0 end-0 m-3" data-bs-dismiss="modal" aria-label="Close"></button>
                         <h4 class="modal-title mb-4 d-flex align-items-center gap-2" id="modalDetalleClaseLabel">
                             <i class="bi bi-info-circle-fill text-primary"></i> Class Details
                         </h4>
@@ -266,10 +267,6 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
                             <button id="btnEliminarClase" class="btn btn-danger" title="Delete Class">
                                 <i class="bi bi-trash3-fill"></i>
                                 <span class="texto-responsive">Delete</span>
-                            </button>
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" title="Close">
-                                <i class="bi bi-x-circle"></i>
-                                <span class="texto-responsive">Close</span>
                             </button>
                         </div>
 

--- a/profesor.php
+++ b/profesor.php
@@ -83,6 +83,7 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
     <div class="modal-dialog modal-dialog-centered modal-detalle-clase">
         <!-- Modal Content -->
         <div class="modal-content compacto">
+            <button type="button" class="btn-close position-absolute top-0 end-0 m-3" data-bs-dismiss="modal" aria-label="Close"></button>
             <h4 class="modal-title mb-4 d-flex align-items-center gap-2" id="modalDetalleClaseLabel">
                 <i class="bi bi-info-circle-fill text-primary"></i> Class Details
             </h4>
@@ -146,10 +147,6 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
               <button id="btnEliminarClase" class="btn btn-danger" title="Delete Class">
                 <i class="bi bi-trash3-fill"></i>
                 <span class="texto-responsive">Delete</span>
-              </button>
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" title="Close">
-                <i class="bi bi-x-circle"></i>
-                <span class="texto-responsive">Close</span>
               </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove redundant footer Close button from `#modalDetalleClase`
- add Bootstrap `btn-close` icon in the top-right corner of the modal content

## Testing
- `php -l admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea10d48348322a5493ff52f2f3411