### PR TITLE
Integrate Flatpickr for time inputs

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -29,6 +29,8 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
     <!-- TU CSS PERSONALIZADO SIEMPRE ÚLTIMO -->
     <link rel="stylesheet" href="css/styles.css?v=2.0">
     <link rel="stylesheet" href="css/modal-detalle.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 
     <!-- FOUC Fix -->
     <style>
@@ -310,13 +312,13 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
                                     <label for="hora_inicio" class="form-label d-flex align-items-center gap-1">
                                         <i class="fas fa-clock text-secondary"></i>Start Time 
                                     </label>
-                                    <input type="time" id="hora_inicio" class="form-control" required>
+                                    <input type="text" id="hora_inicio" class="form-control" required placeholder="Start Time">
                                 </div>
                                 <div class="col-md-6">
                                     <label for="hora_fin" class="form-label d-flex align-items-center gap-1">
                                         <i class="fas fa-clock text-secondary"></i>End Time 
                                     </label>
-                                    <input type="time" id="hora_fin" class="form-control" required>
+                                    <input type="text" id="hora_fin" class="form-control" required placeholder="End Time">
                                 </div>
                             </div>
                             <hr class="section-divider">

--- a/js/admin_clases.js
+++ b/js/admin_clases.js
@@ -24,6 +24,22 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!hFin.value) hFin.value = "06:00";
         });
     }
+    const horaInicioPicker = flatpickr("#hora_inicio", {
+      enableTime: true,
+      noCalendar: true,
+      dateFormat: "H:i",
+      time_24hr: true,
+      onChange: function(selectedDates, dateStr, instance) {
+        horaFinPicker.set("minTime", dateStr);
+      }
+    });
+
+    const horaFinPicker = flatpickr("#hora_fin", {
+      enableTime: true,
+      noCalendar: true,
+      dateFormat: "H:i",
+      time_24hr: true
+    });
 });
 
 

--- a/js/profesor/profesor_clases.js
+++ b/js/profesor/profesor_clases.js
@@ -22,6 +22,22 @@ document.addEventListener("DOMContentLoaded", function () {
             if (!hFin.value) hFin.value = "06:00";
         });
     }
+    const horaInicioPicker = flatpickr("#hora_inicio", {
+      enableTime: true,
+      noCalendar: true,
+      dateFormat: "H:i",
+      time_24hr: true,
+      onChange: function(selectedDates, dateStr, instance) {
+        horaFinPicker.set("minTime", dateStr);
+      }
+    });
+
+    const horaFinPicker = flatpickr("#hora_fin", {
+      enableTime: true,
+      noCalendar: true,
+      dateFormat: "H:i",
+      time_24hr: true
+    });
 });
 
 function inicializarCalendario() {

--- a/profesor.php
+++ b/profesor.php
@@ -42,6 +42,8 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/modal-detalle.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 </head>
 
 <body>
@@ -172,11 +174,11 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
                                     </div>
                                     <div class="col-md-6">
                                         <label for="hora_inicio" class="form-label">Start Time</label>
-                                        <input type="time" id="hora_inicio" class="form-control" required>
+                                        <input type="text" id="hora_inicio" class="form-control" required placeholder="Start Time">
                                     </div>
                                     <div class="col-md-6">
                                         <label for="hora_fin" class="form-label">End Time</label>
-                                        <input type="time" id="hora_fin" class="form-control" required>
+                                        <input type="text" id="hora_fin" class="form-control" required placeholder="End Time">
                                     </div>
                                     <div class="col-md-6">
                                         <label for="alumno" class="form-label">Participant Name</label>


### PR DESCRIPTION
## Summary
- load Flatpickr library in admin and teacher views
- switch time fields to text inputs
- initialize Flatpickr instances for start and end time pickers

## Testing
- `php -l admin.php` *(fails: command not found)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686917d007748322b42f954d38ff625b