### PR TITLE
Implement reusable emoji icon helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # surfschool
+
+## Icon System
+
+Common icons across the application are handled through an emoji based helper.
+
+1. `php/iconos.php` maps action names to emojis.
+2. `php/helpers.php` provides `render_icon($key, $size = '1.2rem')` to output
+   the emoji wrapped in a `<span>`.
+3. Include `php/helpers.php` in any PHP file and call `render_icon` where an
+   icon is needed.
+
+Example:
+
+```php
+require_once __DIR__ . '/php/helpers.php';
+echo render_icon('delete');
+```

--- a/admin.php
+++ b/admin.php
@@ -1,6 +1,7 @@
 <?php
 $config = include __DIR__ . '/php/school_config.php';
 require_once __DIR__ . '/php/validar_sesion_admin.php';
+require_once __DIR__ . '/php/helpers.php';
 ?>
 
 <!DOCTYPE html>
@@ -77,7 +78,7 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
             <div class="d-flex justify-content-md-end justify-content-center mb-3">
                 <button class="btn btn-primary d-flex align-items-center gap-2 boton-add-instructor"
                     data-bs-toggle="modal" data-bs-target="#modalAgregarProfesor">
-                    <span class="material-icons" style="font-size:18px;"></span>
+                    <?php echo render_icon('instructor'); ?>
                     Add Instructor
                 </button>
             </div>
@@ -179,7 +180,7 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
 
         <!-- Class Management Section -->
         <div id="clases" class="seccion" style="display: none;">
-            <h3>Class Management</h3>
+            <h3><?php echo render_icon('calendar', '1.5rem'); ?> Class Management</h3>
 
             <!-- Calendar -->
             <p class="text-muted small mb-2">📌 Click on a day in the calendar to schedule a new class</p>
@@ -265,7 +266,7 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
                                 <span class="texto-responsive">Edit</span>
                             </button>
                             <button id="btnEliminarClase" class="btn btn-danger" title="Delete Class">
-                                <i class="bi bi-trash3-fill"></i>
+                                <?php echo render_icon('delete'); ?>
                                 <span class="texto-responsive">Delete</span>
                             </button>
                         </div>

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -1,0 +1,25 @@
+<?php
+// ===========================================================
+// File: helpers.php
+// Purpose: Common helper functions for the application.
+// ===========================================================
+
+/**
+ * Render an emoji icon wrapped in a span element.
+ *
+ * @param string $key  Key of the icon in the icon map.
+ * @param string $size CSS font-size for the emoji. Defaults to '1.2rem'.
+ *
+ * @return string HTML span with the emoji or an empty string if not found.
+ */
+function render_icon(string $key, string $size = '1.2rem'): string
+{
+    $icons = include __DIR__ . '/iconos.php';
+
+    if (!isset($icons[$key])) {
+        return '';
+    }
+
+    $emoji = $icons[$key];
+    return "<span style=\"font-size: {$size}; vertical-align: middle;\">{$emoji}</span>";
+}

--- a/php/iconos.php
+++ b/php/iconos.php
@@ -1,0 +1,15 @@
+<?php
+return [
+  'instructor'    => '🧑‍🏫',
+  'calendar'      => '📅',
+  'alarm'         => '⏰',
+  'email'         => '✉️',
+  'phone'         => '📞',
+  'money'         => '💸',
+  'credit_card'   => '💳',
+  'billing'       => '💰',
+  'delete'        => '🗑️',
+  'edit'          => '✏️',
+  'save'          => '💾',
+  'info'          => 'ℹ️',
+];


### PR DESCRIPTION
## Summary
- add centralized `iconos.php` mapping keys to emojis
- provide `render_icon()` helper
- showcase helper usage in `admin.php`
- document emoji icon system in README

## Testing
- `php -l php/helpers.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edf67dc108322b8175727abca98df