### PR TITLE
Add emoji icon system and CSS tokens

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -1,6 +1,7 @@
 <?php
 $config = include __DIR__ . '/php/school_config.php';
 require_once __DIR__ . '/php/validar_sesion_admin.php';
+require_once __DIR__ . '/php/helpers.php';
 ?>
 
 <!DOCTYPE html>
@@ -27,6 +28,7 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
     <!-- TU CSS PERSONALIZADO SIEMPRE ÚLTIMO -->
+    <link rel="stylesheet" href="css/tokens.css">
     <link rel="stylesheet" href="css/styles.css?v=2.0">
     <link rel="stylesheet" href="css/modal-detalle.css">
 
@@ -42,7 +44,7 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
 <body>
     <div id="loader"
         style="position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:9999;display:flex;align-items:center;justify-content:center;background:#f7f8fa;">
-        <span class="material-icons" style="font-size:2.2rem; color:#2563EB;">hourglass_top</span>
+        <?php echo render_icon('alarm', '2.2rem'); ?>
     </div>
 
     <!-- Navigation bar -->
@@ -77,7 +79,7 @@ require_once __DIR__ . '/php/validar_sesion_admin.php';
             <div class="d-flex justify-content-md-end justify-content-center mb-3">
                 <button class="btn btn-primary d-flex align-items-center gap-2 boton-add-instructor"
                     data-bs-toggle="modal" data-bs-target="#modalAgregarProfesor">
-                    <span class="material-icons" style="font-size:18px;"></span>
+                    <?php echo render_icon('instructor'); ?>
                     Add Instructor
                 </button>
             </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,9 +7,9 @@
     box-sizing: border-box;
 }
 body {
-    font-family: Arial, sans-serif;
-    background-color: #f4f4f4;
-    color: #333;
+    font-family: var(--font-main);
+    background-color: var(--color-light);
+    color: var(--color-dark);
 }
 
 /* ====================================================
@@ -153,17 +153,17 @@ form button {
     min-width: 140px;
 }
 .btn-warning {
-    background-color: #ffcc00;
+    background-color: var(--color-warning);
     border: none;
     color: black;
 }
 .btn-danger {
-    background-color: #dc3545;
+    background-color: var(--color-danger);
     border: none;
     color: white;
 }
 .btn-success {
-    background-color: #28a745;
+    background-color: var(--color-success);
     border: none;
     color: white;
 }
@@ -550,9 +550,9 @@ form button {
 }
 /* ===== GENERAL ===== */
 body {
-    font-family: 'Inter', 'Roboto', Arial, sans-serif;
-    background-color: #F7F8FA;
-    color: #111827;
+    font-family: var(--font-main);
+    background-color: var(--color-light);
+    color: var(--color-dark);
 }
 * {
     margin: 0;
@@ -608,7 +608,7 @@ body {
 
 .btn-primary,
 .boton-add-instructor {
-    background: #2563EB !important;
+    background: var(--color-primary) !important;
     border: none !important;
     color: #FFF !important;
     padding: 0.7em 2em;
@@ -625,13 +625,13 @@ body {
     background: #1E40AF !important;
 }
 .boton-add-instructor:focus {
-    background: #2563EB !important; /* el mismo color normal */
+    background: var(--color-primary) !important; /* el mismo color normal */
     outline: 2px solid #1E40AF; /* opcional: outline visible para accesibilidad */
     outline-offset: 2px;
 }
 
 .btn-success {
-    background: #22C55E !important;
+    background: var(--color-success) !important;
     border: none !important;
     color: #FFF !important;
 }

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,0 +1,19 @@
+:root {
+  --color-primary: #007bff;
+  --color-secondary: #6c757d;
+  --color-success: #28a745;
+  --color-danger: #dc3545;
+  --color-warning: #ffc107;
+  --color-info: #17a2b8;
+  --color-light: #f8f9fa;
+  --color-dark: #343a40;
+
+  --font-main: 'Inter', sans-serif;
+  --font-headings: 'Inter', sans-serif;
+  --font-size-base: 1rem;
+  --font-size-sm: 0.875rem;
+  --font-size-lg: 1.25rem;
+
+  --radius: 0.5rem;
+  --shadow: 0 2px 8px rgba(0,0,0,0.1);
+}

--- a/login.php
+++ b/login.php
@@ -24,6 +24,7 @@ if (isset($_GET['expirada'])) {
 
     <title>Login - <?php echo $config['nombre_escuela']; ?> </title>
 
+    <link rel="stylesheet" href="css/tokens.css">
     <link rel="stylesheet" href="css/styles.css">
 </head>
 

--- a/php/helpers.php
+++ b/php/helpers.php
@@ -1,0 +1,7 @@
+<?php
+function render_icon($key, $size = '1.2rem') {
+  $icons = include __DIR__ . '/iconos.php';
+  if (!isset($icons[$key])) return '';
+  $emoji = $icons[$key];
+  return "<span style='font-size: $size; vertical-align: middle;'>$emoji</span>";
+}

--- a/php/iconos.php
+++ b/php/iconos.php
@@ -1,0 +1,15 @@
+<?php
+return [
+  'instructor'   => '🧑‍🏫',
+  'calendar'     => '📅',
+  'alarm'        => '⏰',
+  'email'        => '✉️',
+  'phone'        => '📞',
+  'money'        => '💸',
+  'credit_card'  => '💳',
+  'billing'      => '💰',
+  'delete'       => '🗑️',
+  'edit'         => '✏️',
+  'save'         => '💾',
+  'info'         => 'ℹ️',
+];

--- a/profesor.php
+++ b/profesor.php
@@ -40,6 +40,7 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/tokens.css">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/modal-detalle.css">
 </head>
@@ -432,6 +433,7 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.23/jspdf.plugin.autotable.min.js"></script>
 
     <!-- Estilos -->
+    <link rel="stylesheet" href="css/tokens.css">
     <link rel="stylesheet" href="css/styles.css?v=2.0">
 
 


### PR DESCRIPTION
## Summary
- centralize icon emojis in `iconos.php` and helper `render_icon`
- provide design tokens for colors, fonts and sizing
- import tokens CSS in PHP pages
- show example icons in `admin.php`
- refactor some CSS rules to use new tokens

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7a02d504832297aa939b69b5d96b