### PR TITLE
Refactor UI to use centralized tokens

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -200,25 +200,25 @@ require_once __DIR__ . '/php/helpers.php';
                         <button type="button" class="btn-close position-absolute top-0 end-0 m-3"
                             data-bs-dismiss="modal" aria-label="Close"></button>
                         <h4 class="modal-title mb-4 d-flex align-items-center gap-2" id="modalDetalleClaseLabel">
-                            <span>ℹ️</span> Class Details
+                            <?php echo render_icon('info'); ?> Class Details
                         </h4>
 
                         <!-- Participant & Instructor -->
                         <div class="section">
                             <p><strong><span>👤</span> Participant:</strong> <span id="detalleAlumno"></span></p>
-                            <p><strong><span>🧑‍🏫</span> Instructor:</strong> <span id="detalleProfesor"></span></p>
+                            <p><strong><?php echo render_icon('instructor'); ?> Instructor:</strong> <span id="detalleProfesor"></span></p>
                         </div>
 
                         <!-- Date & Time -->
                         <div class="section">
-                            <p><strong><span>📅</span> Date:</strong> <span id="detalleFecha"></span></p>
-                            <p><strong><span>⏰</span> Time:</strong> <span id="detalleHorario"></span></p>
+                            <p><strong><?php echo render_icon('calendar'); ?> Date:</strong> <span id="detalleFecha"></span></p>
+                            <p><strong><?php echo render_icon('alarm'); ?> Time:</strong> <span id="detalleHorario"></span></p>
                         </div>
 
                         <!-- Contact Info -->
                         <div class="section">
-                            <p><strong><span>✉️</span> Email:</strong> <span id="detalleEmail"></span></p>
-                            <p><strong><span>📞</span> Phone:</strong> <span id="detalleTelefono"></span></p>
+                            <p><strong><?php echo render_icon('email'); ?> Email:</strong> <span id="detalleEmail"></span></p>
+                            <p><strong><?php echo render_icon('phone'); ?> Phone:</strong> <span id="detalleTelefono"></span></p>
                         </div>
 
                         <!-- Payments -->
@@ -228,11 +228,11 @@ require_once __DIR__ . '/php/helpers.php';
                                 <span id="detallePagoEfectivo" class="badge bg-success-subtle text-success">—</span>
                             </p>
                             <p>
-                                <strong><span>💳</span> Card Payment (€):</strong>
+                                <strong><?php echo render_icon('credit_card'); ?> Card Payment (€):</strong>
                                 <span id="detallePagoTarjeta" class="badge bg-primary-subtle text-primary">—</span>
                             </p>
                             <p>
-                                <strong><span>💰</span> Total Amount (€):</strong>
+                                <strong><?php echo render_icon('billing'); ?> Total Amount (€):</strong>
                                 <span id="detalleImportePagado" class="badge bg-warning-subtle text-warning">—</span>
                             </p>
 
@@ -241,7 +241,7 @@ require_once __DIR__ . '/php/helpers.php';
                         <!-- Instructor rate -->
                         <div class="section">
                             <p>
-                                <strong><span>💸</span> Instructor €/hr:</strong>
+                                <strong><?php echo render_icon('money'); ?> Instructor €/hr:</strong>
                                 <span id="detalleTarifaHora" class="badge bg-secondary-subtle text-dark">—</span>
                             </p>
                         </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,7 @@
     box-sizing: border-box;
 }
 body {
-    font-family: Arial, sans-serif;
+    font-family: var(--font-main);
     background-color: #f4f4f4;
     color: #333;
 }
@@ -55,13 +55,13 @@ body.login-body {
 }
 .login-container input[type="email"]:focus,
 .login-container input[type="password"]:focus {
-    border: 1.5px solid #007bff;
+    border: 1.5px solid var(--color-primary);
     outline: none;
 }
 .login-container button {
     width: 100%;
     padding: 0.75rem;
-    background-color: #007bff;
+    background-color: var(--color-primary);
     border: none;
     border-radius: 8px;
     color: #fff;
@@ -139,7 +139,7 @@ form button {
     text-align: left;
 }
 .table th {
-    background-color: #007bff;
+    background-color: var(--color-primary);
     color: white;
 }
 
@@ -158,7 +158,7 @@ form button {
     color: black;
 }
 .btn-danger {
-    background-color: #dc3545;
+    background-color: var(--color-danger);
     border: none;
     color: white;
 }
@@ -225,7 +225,7 @@ form button {
     border-radius: 4px !important;
 }
 .dataTables_paginate .paginate_button:hover {
-    color: #007bff !important;
+    color: var(--color-primary) !important;
     text-decoration: underline;
 }
 /* Input de página: chico y centrado */
@@ -550,7 +550,7 @@ form button {
 }
 /* ===== GENERAL ===== */
 body {
-    font-family: 'Inter', 'Roboto', Arial, sans-serif;
+    font-family: var(--font-main);
     background-color: #F7F8FA;
     color: #111827;
 }
@@ -695,7 +695,7 @@ body {
     overflow: hidden;
     background: #FFF;
     box-shadow: 0 2px 10px rgba(55, 65, 81, 0.08);
-    font-family: 'Inter', 'Roboto', Arial, sans-serif;
+    font-family: var(--font-main);
     margin-bottom: 2em;
     font-size: 1rem;
 }
@@ -795,7 +795,7 @@ textarea.form-control {
 #modalDetalleClase .modal-content {
     border-radius: 1rem;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-main);
     font-size: 0.92rem;
 }
 
@@ -1000,7 +1000,7 @@ textarea.form-control {
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: var(--font-main);
   background-color: #f7f8fa;
   color: #1f2937;
 }

--- a/login.php
+++ b/login.php
@@ -50,7 +50,7 @@ if (isset($_GET['expirada'])) {
             <a href="#" data-bs-toggle="modal" data-bs-target="#modalReset">Forgot your password?</a>
         </p>
 
-        <p id="error-message" style="color: red; margin-top: 10px;"></p>
+        <p id="error-message" style="color: var(--color-danger); margin-top: 10px;"></p>
     </div>
 
     <!-- 🔐 Password Reset Modal -->

--- a/php/enviar_correo_clase.php
+++ b/php/enviar_correo_clase.php
@@ -108,7 +108,7 @@ foreach ($destinatarios as [$email, $nombre]) {
 
     // ----------- INICIO MENSAJE HTML (caso CANCELACIÓN personalizado) -------------
     if ($tipo === 'eliminar') {
-        $mensajeHTML = "<div style='color: #000; font-family: sans-serif;'>";
+        $mensajeHTML = "<div style='color: #000; font-family: var(--font-main);'>";
         $mensajeHTML .= "<h3 style='color: #000;'>$tituloCorreo</h3>";
         $mensajeHTML .= "<p style='margin-top:20px; color:#000;'>$mensajeIntro</p>";
         $mensajeHTML .= "<ul style='font-size:15px; padding-left:18px;'>";
@@ -133,7 +133,7 @@ foreach ($destinatarios as [$email, $nombre]) {
 
     } else {
         // ----------- MENSAJE HTML para crear/editar: igual que antes -------------
-        $mensajeHTML = "<div style='color: #000; font-family: sans-serif;'>";
+        $mensajeHTML = "<div style='color: #000; font-family: var(--font-main);'>";
         $mensajeHTML .= "<h3 style='color: #000;'>$tituloCorreo</h3>";
 
         if (!$esProfesor) {

--- a/php/registrar_pago.php
+++ b/php/registrar_pago.php
@@ -81,7 +81,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     // ✅ Enviar email al profesor notificando el pago
-    $mensajeHTML = "<div style='color: #000; font-family: sans-serif;'>";
+    $mensajeHTML = "<div style='color: #000; font-family: var(--font-main);'>";
     $mensajeHTML .= "<h3 style='color: #000;'>Payment Registered</h3>";
     $mensajeHTML .= "<p style='margin-top:20px; color:#000;'>Hi <strong>{$profesor_nombre}</strong>,</p>";
     $mensajeHTML .= "<p style='color:#000;'>We have registered a payment to your name on <strong>" . date('d/m/Y') . "</strong> for a total amount of <strong>€{$total}</strong>, corresponding to your completed classes.</p>";

--- a/profesor.php
+++ b/profesor.php
@@ -1,6 +1,7 @@
 <?php
 session_start(); // 🔑 Siempre primero
 $config = include __DIR__ . '/php/school_config.php';
+require_once __DIR__ . '/php/helpers.php';
 // ===============================
 // 🕒 Control de inactividad
 // ===============================
@@ -87,25 +88,25 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
                         <button type="button" class="btn-close position-absolute top-0 end-0 m-3"
                             data-bs-dismiss="modal" aria-label="Close"></button>
                         <h4 class="modal-title mb-4 d-flex align-items-center gap-2" id="modalDetalleClaseLabel">
-                            <span>ℹ️</span> Class Details
+                            <?php echo render_icon('info'); ?> Class Details
                         </h4>
 
                         <!-- Participant & Instructor -->
                         <div class="section">
                             <p><strong><span>👤</span> Participant:</strong> <span id="detalleAlumno"></span></p>
-                            <p><strong><span>🧑‍🏫</span> Instructor:</strong> <span id="detalleProfesor"></span></p>
+                            <p><strong><?php echo render_icon('instructor'); ?> Instructor:</strong> <span id="detalleProfesor"></span></p>
                         </div>
 
                         <!-- Date & Time -->
                         <div class="section">
-                            <p><strong><span>📅</span> Date:</strong> <span id="detalleFecha"></span></p>
-                            <p><strong><span>⏰</span> Time:</strong> <span id="detalleHorario"></span></p>
+                            <p><strong><?php echo render_icon('calendar'); ?> Date:</strong> <span id="detalleFecha"></span></p>
+                            <p><strong><?php echo render_icon('alarm'); ?> Time:</strong> <span id="detalleHorario"></span></p>
                         </div>
 
                         <!-- Contact Info -->
                         <div class="section">
-                            <p><strong><span>✉️</span> Email:</strong> <span id="detalleEmail"></span></p>
-                            <p><strong><span>📞</span> Phone:</strong> <span id="detalleTelefono"></span></p>
+                            <p><strong><?php echo render_icon('email'); ?> Email:</strong> <span id="detalleEmail"></span></p>
+                            <p><strong><?php echo render_icon('phone'); ?> Phone:</strong> <span id="detalleTelefono"></span></p>
                         </div>
 
                         <!-- Payments -->
@@ -115,18 +116,18 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'profesor') {
                                 <span id="detallePagoEfectivo" class="badge bg-success-subtle text-success">—</span>
                             </p>
                             <p>
-                                <strong><span>💳</span> Card Payment (€):</strong>
+                                <strong><?php echo render_icon('credit_card'); ?> Card Payment (€):</strong>
                                 <span id="detallePagoTarjeta" class="badge bg-primary-subtle text-primary">—</span>
                             </p>
                             <p>
-                                <strong><span>💰</span> Total Amount (€):</strong>
+                                <strong><?php echo render_icon('billing'); ?> Total Amount (€):</strong>
                                 <span id="detalleImportePagado" class="fw-bold">—</span>
                             </p>
                         </div>
 
                         <div class="section">
                             <p>
-                                <strong><span>💸</span> Instructor €/hr:</strong>
+                                <strong><?php echo render_icon('money'); ?> Instructor €/hr:</strong>
                                 <span id="detalleTarifaHora" class="badge bg-secondary-subtle text-dark">—</span>
                             </p>
                         </div>


### PR DESCRIPTION
## Summary
- replace inline emojis with `render_icon` helper
- swap hardcoded Bootstrap colors for CSS variables
- switch font declarations to design tokens
- update login error styling
- align email templates with tokenized fonts

## Testing
- `php -l admin.php`
- `php -l profesor.php`
- `php -l php/enviar_correo_clase.php`
- `php -l php/registrar_pago.php`


------
https://chatgpt.com/codex/tasks/task_e_6870b53e67b88322ac6846f146206007